### PR TITLE
Update to current node task version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "ebook-convert": "0.0.2"
+    "ebook-convert": "0.1.0"
   }
 }


### PR DESCRIPTION
Just. Because dependencies. And dragons.
